### PR TITLE
Release 2024.01.31

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,5 +1,78 @@
 ### 2024.01.31
 
+#### @std/io 0.216.0 (minor) 
+- BREAKING(io): remove `types.d.ts` (#4237)
+- feat(io): un-deprecate `Buffer` (#4184)
+- docs(io): fix `io` module is marked deprecated (#4252)
+
+#### @std/expect 0.213.3 (patch) 
+- fix(expect): add Error object equal check. (#4248)
+- fix(expect): align `toEqual` to jest (#4246)
+- fix(expect): fix the function signature of `toMatchObject()` (#4202)
+
+#### @std/log 0.216.0 (minor) 
+- BREAKING(log): remove string formatter (#4239)
+- BREAKING(log): single-export handler files (#4236)
+- feat(tools,log,http,semver): check mod exports, export items consistently from mod.ts  (#4229)
+- feat(log): make handlers disposable (#4195)
+- fix(log): make `flattenArgs()` private (#4214)
+- refactor(log): remove log private methods/properties underscore  (#4243)
+- refactor(log): tidy imports and exports (#4215)
+- refactor(log): replace deprecated imports (#4188)
+
+#### @std/http 0.216.0 (minor) 
+- BREAKING(http): remove `CookieMap` (#4179)
+- feat(tools,log,http,semver): check mod exports, export items consistently from mod.ts  (#4229)
+- docs(http): complete documentation (#4209)
+
+#### @std/semver 0.216.0 (minor) 
+- BREAKING(semver): remove `FormatStyle` (#4182)
+- BREAKING(semver): remove `compareBuild()` (#4181)
+- BREAKING(semver): remove `rsort()` (#4180)
+- feat(tools,log,http,semver): check mod exports, export items consistently from mod.ts  (#4229)
+- deprecation(semver): rename `eq()`, `neq()`, `lt()`, `lte()`, `gt()` and `gte()` (#4083)
+- deprecation(semver): deprecate `SemVerRange`, introduce `Range` (#4161)
+- deprecation(semver): deprecate `outside()` (#4185)
+- refactor(semver): replace `parseComparator()` with comparator objects (#4204)
+
+#### @std/streams 0.216.0 (minor) 
+- BREAKING(streams): remove `readAll()`, `writeAll()` and `copy()` (#4238)
+- docs(streams): remove `Deno.metrics()` use in example (#4217)
+
+#### @std/webgpu 0.213.3 (patch) 
+- refactor(webgpu): use internal `Deno.close()` for cleanup of WebGPU resources (#4231)
+
+#### @std/collections 0.216.0 (minor) 
+- feat(collections): pass `key` to `mapValues()` transformer (#4127)
+
+#### @std/toml 0.213.3 (patch) 
+- fix(toml): `parse()` duplicates the character next to reserved escape sequences (#4192)
+- docs(toml): complete documentation (#4223)
+- test(toml): improve test coverage (#4211)
+
+#### @std/path 0.213.3 (patch) 
+- deprecation(path): split off all constants into their own files and deprecate old names (#4153)
+
+#### @std/msgpack 0.213.3 (patch) 
+- docs(msgpack): complete documentation (#4220)
+
+#### @std/media_types 0.213.3 (patch) 
+- docs(media_types): complete documentation (#4219)
+
+#### @std/console 0.213.3 (patch) 
+- refactor(console): rename `_rle` to `_run_length.ts` (#4212)
+
+#### @std/fmt 0.213.3 (patch) 
+- fix(fmt): correct `stripColor()` deprecation notice (#4208)
+
+#### @std/flags 0.213.3 (patch) 
+- fix(flags): correct deprecation notices (#4207)
+
+#### @std/crypto 0.213.3 (patch) 
+- chore(crypto): upgrade to `rust@1.75.0` and `wasmbuild@0.15.5` (#4193)
+
+### 2024.01.31
+
 #### @std/io 0.215.0 (minor) 
 - BREAKING(io): remove `types.d.ts` (#4237)
 - feat(io): un-deprecate `Buffer` (#4184)

--- a/collections/deno.json
+++ b/collections/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/collections",
-  "version": "0.215.0",
+  "version": "0.216.0",
   "exports": {
     ".": "./mod.ts",
     "./aggregate_groups": "./aggregate_groups.ts",

--- a/console/deno.json
+++ b/console/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/console",
-  "version": "0.213.2",
+  "version": "0.213.3",
   "exports": {
     ".": "./mod.ts",
     "./unicode_width": "./unicode_width.ts"

--- a/crypto/deno.json
+++ b/crypto/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/crypto",
-  "version": "0.213.2",
+  "version": "0.213.3",
   "exports": {
     ".": "./mod.ts",
     "./crypto": "./crypto.ts",

--- a/expect/deno.json
+++ b/expect/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/expect",
-  "version": "0.213.2",
+  "version": "0.213.3",
   "exports": {
     ".": "./mod.ts",
     "./expect": "./expect.ts",

--- a/flags/deno.json
+++ b/flags/deno.json
@@ -1,5 +1,5 @@
 {
   "name": "@std/flags",
-  "version": "0.213.2",
+  "version": "0.213.3",
   "exports": "./mod.ts"
 }

--- a/fmt/deno.json
+++ b/fmt/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/fmt",
-  "version": "0.213.2",
+  "version": "0.213.3",
   "exports": {
     "./bytes": "./bytes.ts",
     "./colors": "./colors.ts",

--- a/http/deno.json
+++ b/http/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/http",
-  "version": "0.215.0",
+  "version": "0.216.0",
   "exports": {
     ".": "./mod.ts",
     "./cookie": "./cookie.ts",

--- a/io/deno.json
+++ b/io/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/io",
-  "version": "0.215.0",
+  "version": "0.216.0",
   "exports": {
     ".": "./mod.ts",
     "./buf_reader": "./buf_reader.ts",

--- a/log/deno.json
+++ b/log/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/log",
-  "version": "0.215.0",
+  "version": "0.216.0",
   "exports": {
     ".": "./mod.ts",
     "./base_handler": "./base_handler.ts",

--- a/media_types/deno.json
+++ b/media_types/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/media_types",
-  "version": "0.213.2",
+  "version": "0.213.3",
   "exports": {
     ".": "./mod.ts",
     "./content_type": "./content_type.ts",

--- a/msgpack/deno.json
+++ b/msgpack/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/msgpack",
-  "version": "0.213.2",
+  "version": "0.213.3",
   "exports": {
     ".": "./mod.ts",
     "./decode": "./decode.ts",

--- a/path/deno.json
+++ b/path/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/path",
-  "version": "0.213.2",
+  "version": "0.213.3",
   "exports": {
     ".": "./mod.ts",
     "./basename": "./basename.ts",

--- a/semver/deno.json
+++ b/semver/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/semver",
-  "version": "0.215.0",
+  "version": "0.216.0",
   "exports": {
     ".": "./mod.ts",
     "./can_parse": "./can_parse.ts",

--- a/streams/deno.json
+++ b/streams/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/streams",
-  "version": "0.215.0",
+  "version": "0.216.0",
   "exports": {
     ".": "./mod.ts",
     "./buffer": "./buffer.ts",

--- a/toml/deno.json
+++ b/toml/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/toml",
-  "version": "0.213.2",
+  "version": "0.213.3",
   "exports": {
     ".": "./mod.ts",
     "./parse": "./parse.ts",

--- a/webgpu/deno.json
+++ b/webgpu/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/webgpu",
-  "version": "0.213.2",
+  "version": "0.213.3",
   "exports": {
     ".": "./mod.ts",
     "./create_capture": "./create_capture.ts",


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|io|0.215.0|0.216.0|minor|
|expect|0.213.2|0.213.3|patch|
|log|0.215.0|0.216.0|minor|
|http|0.215.0|0.216.0|minor|
|semver|0.215.0|0.216.0|minor|
|streams|0.215.0|0.216.0|minor|
|webgpu|0.213.2|0.213.3|patch|
|collections|0.215.0|0.216.0|minor|
|toml|0.213.2|0.213.3|patch|
|path|0.213.2|0.213.3|patch|
|msgpack|0.213.2|0.213.3|patch|
|media_types|0.213.2|0.213.3|patch|
|console|0.213.2|0.213.3|patch|
|fmt|0.213.2|0.213.3|patch|
|flags|0.213.2|0.213.3|patch|
|crypto|0.213.2|0.213.3|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly

The following commits are not recognized. Please handle them manually if necessary:

- [experiment](/kt3k/deno_std/commit/0ce9c2bf7e5f2a096e2e62364a779651c91055cc)

The following commits have unknown scopes. Please handle them manually if necessary:

- [feat(tools,log,http,semver): check mod exports, export items consistently from mod.ts  (#4229)](/kt3k/deno_std/commit/d23718945e1d8c637a48900e23ac38dbc0ca6234)
- [refactor(using): use `using` keyword for Explicit Resource Management (#4143)](/kt3k/deno_std/commit/3fcb0a8b240f72dd4883299d2cd9f778ea868372)

Required scopes are missing in the following commits. Please handle them manually if necessary:

- [fix: ignore linting for `Deno.serveHttp()` (#4234)](/kt3k/deno_std/commit/d91123ee375cca881ff165eae15909e4e49ad8f5)
- [fix: ignore linting rule for `Deno.resources()` (#4233)](/kt3k/deno_std/commit/6a255d137b7e29da4057bd3929f8e023e2eee61d)
- [feat: print warning on use of deprecated API (#4200)](/kt3k/deno_std/commit/88b5f471ed4daef1ee28608059ccd9859b0bcf01)

The following commits are ignored:

- [chore: update versions](/kt3k/deno_std/commit/01292fe9e96c04b06f81e68ef0da6f492fecf617)
- [chore: set up workspace publish from CI (#4210)](/kt3k/deno_std/commit/6dad7609c3b77fe46f46af6091f2404ab6120288)
- [docs: fix broken `{@link}` hyperlinks (#4241)](/kt3k/deno_std/commit/593e344543c956127bed3d85ec2a07b363304c9e)
- [refactor: use granular `--unstable-*` CLI flags (#4232)](/kt3k/deno_std/commit/845a6f8d9799f3de089247f6b41569d900e63a6b)
- [refactor: use `Deno.stdin.isTerminal()` (#4230)](/kt3k/deno_std/commit/14a24c61d04d52b90de36605fa65c448a48c2ff8)
- [refactor: remove environment variable functionality notice in `warnOnDeprecatedApi()` (#4227)](/kt3k/deno_std/commit/f5547f4b2d9bf7bb1204a6b4c073df8c6e2d4c2e)
- [docs: add "Minimal Exports" explainer (#4194)](/kt3k/deno_std/commit/1e85cb08f76914b0a346abf180062e543724dea2)
- [chore: add more explicit types for fast check (#4206)](/kt3k/deno_std/commit/ce9795ab61f04d301f82abd9de5a18fd6fc55152)
- [refactor: cleanup deprecated-related APIs in `std/io` and `std/streams` (#4201)](/kt3k/deno_std/commit/5b0ff30bbf386db647b7c05c1ac1d5bdb807bb0c)

---

To make edits to this PR:

```sh
git fetch upstream release_0_213.0 && git checkout -b release_0_213.0 upstream/release_0_213.0
```
